### PR TITLE
improve/2.1.0-tag-update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/base:alpine
+FROM alpine:3.15.0
 MAINTAINER Dmitry Teikovtsev <teikovtsev.dmitry@pdffiller.team>
 
 ARG BUILD_ID
@@ -17,43 +17,30 @@ ENV BUILD_ID=${BUILD_ID:-"1"} \
 ENV FILEBEAT_VERSION=${FILEBEAT_VERSION:-"6.7.1"} \
     CONSUL_VERSION=${CONSUL_TEMPLATE_VERSION:-"0.22.0"} \
     ALPINE_GLIBC_PACKAGE_VERSION=${ALPINE_GLIBC_PACKAGE_VERSION:-"2.23-r1"} \
-    ALPINE_GLIBC_BASE_URL="https://github.com/andyshinn/alpine-pkg-glibc/releases/download" \
     FILEBEAT_BASE_URL="https://artifacts.elastic.co/downloads/beats/filebeat" \
     CONSUL_BASE_URL="https://releases.hashicorp.com/consul-template"
 
 # install filebeat
 ADD . /etc/filebeat/
-ENV ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-${ALPINE_GLIBC_PACKAGE_VERSION}.apk" \
-    ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-${ALPINE_GLIBC_PACKAGE_VERSION}.apk" \
-    ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-${ALPINE_GLIBC_PACKAGE_VERSION}.apk"
 RUN set -ex  && apk --no-cache add --virtual .build-dependencies wget ca-certificates  && \
-    wget "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE_VERSION}/${ALPINE_GLIBC_BASE_PACKAGE_FILENAME}" \
-    "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE_VERSION}/${ALPINE_GLIBC_BIN_PACKAGE_FILENAME}" \
-    "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE_VERSION}/${ALPINE_GLIBC_I18N_PACKAGE_FILENAME}" && \
-    apk add --no-cache --allow-untrusted "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true \
-    && echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && apk del glibc-i18n && \
-    apk del .build-dependencies && rm "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-    "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
+    apk add --no-cache supervisor gcompat && \
     wget "${FILEBEAT_BASE_URL}/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz" \
     -O /tmp/filebeat.tar.gz && \
     cd /tmp && tar xzvf filebeat.tar.gz && \
     cd filebeat-* && rm *.txt && rm *.md && cp -r * /etc/filebeat/ && \
     cd /tmp && rm -rf filebeat* && \
     ln -s /etc/filebeat/filebeat /usr/local/bin/filebeat && \
-    chmod +x /etc/filebeat/provision/*.sh
-
-# install consul-template
-RUN wget "${CONSUL_BASE_URL}/${CONSUL_VERSION}/consul-template_${CONSUL_VERSION}_linux_amd64.zip" \
+    chmod +x /etc/filebeat/provision/*.sh && \
+    wget "${CONSUL_BASE_URL}/${CONSUL_VERSION}/consul-template_${CONSUL_VERSION}_linux_amd64.zip" \
     -O /tmp/consul-template.zip && \
     cd /tmp && unzip consul-template.zip && \
     mv /tmp/consul-template /usr/local/bin/consul-template && \
-    chmod +x /usr/local/bin/consul-template
+    chmod +x /usr/local/bin/consul-template && \
+    apk del .build-dependencies
 
 # prepare supervisor
-RUN mv /etc/filebeat/supervisor/*.conf /opt/docker/etc/supervisor.d/ && \
-    rm /opt/docker/etc/supervisor.d/dnsmasq.conf && \
-    rm /opt/docker/etc/supervisor.d/ssh.conf && \
-    rm /opt/docker/etc/supervisor.d/postfix.conf && \
-    rm /opt/docker/etc/supervisor.d/syslog.conf
+RUN mkdir -p /var/log/supervisor/ /etc/supervisor.d/ && \
+    mv /etc/filebeat/supervisor/*.conf  /etc/supervisor.d/ && \
+    mv /etc/filebeat/supervisord.conf /etc/supervisord.conf
+
+ENTRYPOINT ["supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV BUILD_ID=${BUILD_ID:-"1"} \
     SERVICE_ENV="stage"
 
 # utilites version
-ENV FILEBEAT_VERSION=${FILEBEAT_VERSION:-"6.5.4"} \
+ENV FILEBEAT_VERSION=${FILEBEAT_VERSION:-"6.7.1"} \
     CONSUL_VERSION=${CONSUL_TEMPLATE_VERSION:-"0.22.0"} \
     ALPINE_GLIBC_PACKAGE_VERSION=${ALPINE_GLIBC_PACKAGE_VERSION:-"2.23-r1"} \
     ALPINE_GLIBC_BASE_URL="https://github.com/andyshinn/alpine-pkg-glibc/releases/download" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV BUILD_ID=${BUILD_ID:-"1"} \
 
 # utilites version
 ENV FILEBEAT_VERSION=${FILEBEAT_VERSION:-"6.5.4"} \
-    CONSUL_VERSION=${CONSUL_TEMPLATE_VERSION:-"0.18.1"} \
+    CONSUL_VERSION=${CONSUL_TEMPLATE_VERSION:-"0.22.0"} \
     ALPINE_GLIBC_PACKAGE_VERSION=${ALPINE_GLIBC_PACKAGE_VERSION:-"2.23-r1"} \
     ALPINE_GLIBC_BASE_URL="https://github.com/andyshinn/alpine-pkg-glibc/releases/download" \
     FILEBEAT_BASE_URL="https://artifacts.elastic.co/downloads/beats/filebeat" \
@@ -30,11 +30,11 @@ RUN set -ex  && apk --no-cache add --virtual .build-dependencies wget ca-certifi
     wget "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE_VERSION}/${ALPINE_GLIBC_BASE_PACKAGE_FILENAME}" \
     "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE_VERSION}/${ALPINE_GLIBC_BIN_PACKAGE_FILENAME}" \
     "${ALPINE_GLIBC_BASE_URL}/${ALPINE_GLIBC_PACKAGE_VERSION}/${ALPINE_GLIBC_I18N_PACKAGE_FILENAME}" && \
-     apk add --no-cache --allow-untrusted "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+    apk add --no-cache --allow-untrusted "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
     "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-     /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true \
-     && echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && apk del glibc-i18n && \
-     apk del .build-dependencies && rm "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
+    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true \
+    && echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && apk del glibc-i18n && \
+    apk del .build-dependencies && rm "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
     "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
     wget "${FILEBEAT_BASE_URL}/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz" \
     -O /tmp/filebeat.tar.gz && \

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+### 2.1.0
+   UPDATED:
+     - Filebeat version to 6.7.1
+     - Consul-Template version to 0.22.0
+     - Removed environment variable from provisioning script
+     - Elasticsearch output configuration to use docker labels
+  
+   ADD:
+     - Filebeat.Input: Docker
+     - Docker and Cloud metadata processors
+     - Consul Key for logging level (default level is info)
 ### 2.0.3
 
    ADD:

--- a/consul/prospectors.ctmpl
+++ b/consul/prospectors.ctmpl
@@ -1,18 +1,26 @@
-{{range $key, $pairs := tree "SERVICE_KV_PATH/CLUSTER_NAME" |byKey}}
-
-- type: log
+{{ range $key,$pairs := printf "SERVICE_KV_PATH/CLUSTER_NAME" | tree | explode }}
+{{ if $pairs.type }}
+- type: {{ $pairs.type }}{{ else }}
+- type: log {{ end }}
+{{ if  $pairs.type | contains "docker" }}
+  containers:
+    path: "{{ $pairs.path }}"
+    stream: "all"
+    ids:
+      - "*"
+{{ else }}
   paths:
-  - {{$pairs.path.Value}}
+  - {{ $pairs.path }}
+{{ end }}
   fields:
-   document_type: {{$pairs.doc_type.Value}}
-   index_prefix: {{with $pairs.index_prefix.Value}}{{$pairs.index_prefix.Value}}{{else}}filebeat{{end}}
+   document_type: {{ $pairs.doc_type }}
+   index_prefix: {{ with $pairs.index_prefix }}{{ $pairs.index_prefix }}{{ else }}filebeat{{ end }}
 
-  {{if $pairs.json.Value }}
+{{ if $pairs.json }}
   json:
     -json.keys_under_root: true
     -json.add_error_key: true
     -json.message_key: message
-    {{else}}
-    {{end}}
+{{ end }}
   scan_frequency: 10s
-  {{end}}
+{{ end }}

--- a/consul/template.ctmpl
+++ b/consul/template.ctmpl
@@ -4,19 +4,59 @@ filebeat.config.inputs:
   reload.enabled: true
   reload.period: 10s
 
+#=========================== Filebeat processors =============================
+
+processors:
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
+
 #================================ General =====================================
 name: "CLUSTER_NAME"
 tags: ["CLUSTER_NAME", "json"]
 
 output.elasticsearch:
   enabled: true
-  hosts: ["{{key "SERVICE_KV_PATH/config/es_host"}}:{{key "SERVICE_KV_PATH/config/es_port"}}"]
-  index: "SERVICE_ENV-%{[fields.index_prefix]}-%{+yyyy.MM.dd}"
+  hosts: 
+    - "{{ key "SERVICE_KV_PATH/config/es_host" }}:{{ key "SERVICE_KV_PATH/config/es_port" }}"
   template.name: "filebeat"
+  indices:
+    - index: "%{[beat.name]}-%{+yyyy.MM.dd}"
+      when.and:
+        - equals:
+            prospector.type: "docker"
+        - equals:
+            docker.container.labels.filebeat.enable: "true"
+        - equals:
+            docker.container.labels.service.application: "app"
+        - not:
+            equals:
+              docker.container.labels.filebeat.index: "custom"
+    - index: "SERVICE_ENV-http-%{+yyyy.MM.dd}"
+      when.and:
+        - equals:
+            prospector.type: "docker"
+        - equals:
+            docker.container.labels.filebeat.enable: "true"
+        - equals:
+            docker.container.labels.service.application: "http"
+    - index: "%{[fields.index_prefix]}-%{+yyyy.MM.dd}"
+      when.and:
+        - equals:
+            prospector.type: "docker"
+        - equals:
+            docker.container.labels.filebeat.enable: "true"
+        - equals:
+            docker.container.labels.filebeat.index: "custom"
+#### supports old fashioned log prospector type
+    - index: "SERVICE_ENV-%{[fields.index_prefix]}-%{+yyyy.MM.dd}"
+      when.equals:
+        prospector.type: "log"
 
 setup.template:
   name: "SERVICE_ENV"
   pattern: "SERVICE_ENV-*"
 
 #================================ Logging =====================================
-logging.level: debug
+logging.level: {{ keyOrDefault "SERVICE_KV_PATH/config/debug" "info" }}
+
+

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -9,4 +9,4 @@ sed -i "s|CLUSTER_NAME|${CLUSTER_NAME}|g"        /etc/filebeat/consul/template.c
 sed -i "s|SERVICE_ENV|${SERVICE_ENV}|g"          /etc/filebeat/consul/template.ctmpl
 sed -i "s|SERVICE_KV_PATH|${SERVICE_KV_PATH}|g"  /etc/filebeat/consul/template.ctmpl
 
-/usr/local/bin/consul-template --log-level=debug --consul-addr=${CONSUL_HTTP_ADDR} -config=/etc/filebeat/consul/consul.hcl
+/usr/local/bin/consul-template --log-level=debug  -config=/etc/filebeat/consul/consul.hcl

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,13 @@
 Filebeat configuring via Consul
 
 ### Environment Variables
-| Name | Description | Default |
-|------|-------------|---------|
-| SERVICE_KV_PATH | The path to filebeat folder with config KV in consul |"filebeat" |
-| CONSUL_TOKEN | The consul acl token. See https://www.consul.io/docs/guides/acl.html#acl-agent-token | |
-| CONSUL_HTTP_ADDR | The consul URL | http://172.17.0.1:8500 |
-| CLUSTER_NAME | The additional subfolders in KV path for different filebit instances | ecs-cluster |
-| SERVICE_ENV | The additional prefix to elasticsearch indexname |stage|
+| Name             | Description                                                                          | Default                |
+| ---------------- | ------------------------------------------------------------------------------------ | ---------------------- |
+| SERVICE_KV_PATH  | The path to filebeat folder with config KV in consul                                 | "filebeat"             |
+| CONSUL_TOKEN     | The consul acl token. See https://www.consul.io/docs/guides/acl.html#acl-agent-token |                        |
+| CONSUL_HTTP_ADDR | The consul URL                                                                       | http://172.17.0.1:8500 |
+| CLUSTER_NAME     | The additional subfolders in KV path for different filebit instances                 | ecs-cluster            |
+| SERVICE_ENV      | The additional prefix to elasticsearch indexname                                     | stage                  |
 
 ### Mount Points
 /var/log/       logs
@@ -17,8 +17,8 @@ Filebeat configuring via Consul
 ![](https://raw.githubusercontent.com/pdffillerdocker/filebeat-consul/master/_docs/filebeat.png)
 
 ### Configure the cleaner
-| Name | Description |
-|------|-------------|
+| Name     | Description                                                                      |
+| -------- | -------------------------------------------------------------------------------- |
 | logs_TTL | Time in min. If during the specified time the file is not changed, it is deleted |
 
 ### Sample configure cleaner (put consul KV via bash script)
@@ -28,14 +28,14 @@ Filebeat configuring via Consul
 SERVICE_KV_PATH="filebeat"
 CONSUL_SERVER_URL="http://localhost:8500"
 
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/config/logs_TTL <<< "180"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/config/logs_TTL <<< "180"
 ```
 
 ### Configure the output
-| Name | Description |
-|------|-------------|
+| Name    | Description              |
+| ------- | ------------------------ |
 | es_host | The elasticsearch addres |
-| es_port | The elasticsearch port |
+| es_port | The elasticsearch port   |
 
 ### Sample configure output (put consul KV via bash script)
 ```bash
@@ -44,17 +44,17 @@ curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/config/logs_TTL <
 SERVICE_KV_PATH="filebeat"
 CONSUL_SERVER_URL="http://localhost:8500"
 
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/config/es_host <<< "localhost"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/config/es_port <<< "9200"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/config/es_host <<< "localhost"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/config/es_port <<< "9200"
 ```
 
 ### Configure inputs
-| Name | Description |
-|------|-------------|
-| doc_type | The value for fileds document_type |
+| Name         | Description                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| doc_type     | The value for fileds document_type                                                                                     |
 | index_prefix | The elasticsearch index prefix. Result elasticsearch prefix like "SERVICE_ENV-%{[fields.index_prefix]}-%{+yyyy.MM.dd}" |
-| json | Boolean value. Set true if log in json format |
-| path | The parsing file mask |
+| json         | Boolean value. Set true if log in json format                                                                          |
+| path         | The parsing file mask                                                                                                  |
 
 ### Sample configure inputs (put consul KV via bash script)
 ```bash
@@ -64,26 +64,26 @@ CLUSTER_NAME="ecs-cluster"
 SERVICE_KV_PATH="filebeat"
 CONSUL_SERVER_URL="http://localhost:8500"
 
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-access/doc_type <<< "container-1-nginx-access"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-access/index_prefix <<< "nginx-access"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-access/json <<< "1"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-access/path <<< "/var/log/container_1/nginx/*.json"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-access/doc_type <<< "container-1-nginx-access"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-access/index_prefix <<< "nginx-access"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-access/json <<< "1"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-access/path <<< "/var/log/container_1/nginx/*.json"
 
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-error/doc_type <<< "container-1-nginx-error"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-error/index_prefix <<< "nginx-error"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-error/json <<< "0"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-1-nginx-error/path <<< "/var/log/container_1/nginx/*.log"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-error/doc_type <<< "container-1-nginx-error"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-error/index_prefix <<< "nginx-error"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-error/json <<< "0"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-error/path <<< "/var/log/container_1/nginx/*.log"
 
 
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-access/doc_type <<< "container-2-nginx-access"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-access/index_prefix <<< "nginx-access"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-access/json <<< "1"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-access/path <<< "/var/log/container_1/nginx/*.json"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-access/doc_type <<< "container-2-nginx-access"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-access/index_prefix <<< "nginx-access"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-access/json <<< "1"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-access/path <<< "/var/log/container_1/nginx/*.json"
 
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-error/doc_type <<< "container-2-nginx-error"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-error/index_prefix <<< "nginx-error"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-error/json <<< "0"
-curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/{SERVICE_KV_PATH}/{CLUSTER_NAME}/container-2-nginx-error/path <<< "/var/log/container_2/nginx/*.log"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/doc_type <<< "container-2-nginx-error"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/index_prefix <<< "nginx-error"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/json <<< "0"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/path <<< "/var/log/container_2/nginx/*.log"
 ```
 
 # sample keys used filebeat-consul
@@ -117,11 +117,11 @@ curl --header "X-Consul-Token: 1234sampletoken" "http://localhost:8500/v1/kv/fil
 ```
 
 ### additional build parameters
-| Name | Description | Default |
-|------|-------------|---------|
-| FILEBEAT_VERSION | The filebeat version | 6.5.4 |
-| CONSUL_TEMPLATE_VERSION | The consul-template version | 0.18.1 |
-| ALPINE_GLIBC_PACKAGE_VERSION | The glibc version | 2.23-r1 |
+| Name                         | Description                 | Default |
+| ---------------------------- | --------------------------- | ------- |
+| FILEBEAT_VERSION             | The filebeat version        | 6.5.4   |
+| CONSUL_TEMPLATE_VERSION      | The consul-template version | 0.18.1  |
+| ALPINE_GLIBC_PACKAGE_VERSION | The glibc version           | 2.23-r1 |
 
 ### useful links
 [Filebeat Reference](https://www.elastic.co/guide/en/beats/filebeat/current/index.html)

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Filebeat configuring via Consul
 | -------- | -------------------------------------------------------------------------------- |
 | logs_TTL | Time in min. If during the specified time the file is not changed, it is deleted |
 
-### Sample configure cleaner (put consul KV via bash script)
+#### Sample configure cleaner (put consul KV via bash script)
 ```bash
 #!/bin/bash
 
@@ -49,12 +49,13 @@ curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/config/es_port <
 ```
 
 ### Configure inputs
-| Name         | Description                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| doc_type     | The value for fileds document_type                                                                                     |
-| index_prefix | The elasticsearch index prefix. Result elasticsearch prefix like "SERVICE_ENV-%{[fields.index_prefix]}-%{+yyyy.MM.dd}" |
-| json         | Boolean value. Set true if log in json format                                                                          |
-| path         | The parsing file mask                                                                                                  |
+| Name         | Description                                                                                                            | Mandatory        | Default |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
+| type         | The Filebeat Input type. Example: docker                                                                               | no               | log     |
+| doc_type     | The value for fileds document_type                                                                                     | yes              |         |
+| index_prefix | The elasticsearch index prefix. Result elasticsearch prefix like "SERVICE_ENV-%{[fields.index_prefix]}-%{+yyyy.MM.dd}" | if type log: yes |         |
+| json         | Boolean value. Set true if log in json format                                                                          | yes              |         |
+| path         | The parsing file mask (for docker use: /var/lib/docker/containers)                                                     | yes              |         |
 
 ### Sample configure inputs (put consul KV via bash script)
 ```bash
@@ -84,6 +85,14 @@ curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/
 curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/index_prefix <<< "nginx-error"
 curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/json <<< "0"
 curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-2-nginx-error/path <<< "/var/log/container_2/nginx/*.log"
+
+#### docker test 
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-nginx-docker/type <<< "docker"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-docker/doc_type <<< "container-1-nginx-docker"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-docker/index_prefix <<< "nginx-docker"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-docker/json <<< "1"
+curl -X PUT -d @- ${CONSUL_SERVER_URL}/v1/kv/${SERVICE_KV_PATH}/${CLUSTER_NAME}/container-1-docker/path <<< "/var/lib/docker/containers"
+
 ```
 
 # sample keys used filebeat-consul
@@ -119,8 +128,8 @@ curl --header "X-Consul-Token: 1234sampletoken" "http://localhost:8500/v1/kv/fil
 ### additional build parameters
 | Name                         | Description                 | Default |
 | ---------------------------- | --------------------------- | ------- |
-| FILEBEAT_VERSION             | The filebeat version        | 6.5.4   |
-| CONSUL_TEMPLATE_VERSION      | The consul-template version | 0.18.1  |
+| FILEBEAT_VERSION             | The filebeat version        | 6.7.1   |
+| CONSUL_TEMPLATE_VERSION      | The consul-template version | 0.22.0  |
 | ALPINE_GLIBC_PACKAGE_VERSION | The glibc version           | 2.23-r1 |
 
 ### useful links

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+nodaemon=true
+
+[unix_http_server]
+file = /.supervisor.sock
+chmod = 0700
+chown = root:root
+username = root
+password = {SHA}e982f17bcbe0f724063b708a4f76db211a999304
+
+[supervisorctl]
+serverurl = unix:///.supervisor.sock
+username = root
+password = docker
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[include]
+files = /opt/docker/etc/supervisor.d/*.conf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,4 +17,4 @@ password = docker
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [include]
-files = /opt/docker/etc/supervisor.d/*.conf
+files = /etc/supervisor.d/*.conf


### PR DESCRIPTION
Improved 2.1.0
Use vanilla alpine instead of custom webdevops/base, get rid of untrusted glibc package
I've built filebeat images using these changes using tag 2.1.1, I think it is reasonable to release the code with the same tag